### PR TITLE
Open External link in a new tab. 

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -57,6 +57,7 @@ class Link extends React.Component {
         )}
         href={to}
         onClick={onClick}
+        target="_blank"
       >
         {children}
       </a>


### PR DESCRIPTION
change the behavior of external link, which will open in a new tab instead of replacing current tab