### PR TITLE
fix: update import from sections/evidence/KidsFirst to sections/evide…

### DIFF
--- a/src/pages/EvidencePage/sections.js
+++ b/src/pages/EvidencePage/sections.js
@@ -20,7 +20,7 @@ import * as SysBio from '../../sections/evidence/SysBio';
 import * as UniProtLiterature from '../../sections/evidence/UniProtLiterature';
 import * as UniProtVariants from '../../sections/evidence/UniProtVariants';
 import * as Orphanet from '../../sections/evidence/Orphanet';
-import * as KidsFirst from '../../sections/evidence/KidsFirst';
+import * as OpenPedCanGeneExpression from '../../sections/evidence/OpenPedCanGeneExpression';
 import * as OpenPedCanSomaticMutations from '../../sections/evidence/OpenPedCanSomaticMutations'
 
 const sections = [
@@ -45,7 +45,7 @@ const sections = [
   EuropePmc,
   ExpressionAtlas,
   Phenodigm,
-  KidsFirst,
   OpenPedCanSomaticMutations,
+  OpenPedCanGeneExpression,
 ];
 export default sections;


### PR DESCRIPTION
In this PR, I have fix an importing error that was occurring under 'src/pages/EvidencePage/sections.js'. The cause is because one of the section was being imported from an older directory name ('/sections/evidence/KidsFirst'). I have now updated to import from the updated directory name called '/sections/evidence/OpenPedCanGeneExpression'.