### PR TITLE
PPDC-309 - update "OpenPedCan Gene Expression" widget under evidence page

### DIFF
--- a/src/sections/evidence/OpenPedCanGeneExpression/Description.js
+++ b/src/sections/evidence/OpenPedCanGeneExpression/Description.js
@@ -1,15 +1,25 @@
 import React from 'react';
 import Link from '../../../components/Link';
- /*-<Link to="https://www.ebi.ac.uk/gxa/home" external>
-      Method of comparison
-   </Link> */
+
 const Description = ({ symbol, name }) => (
   <>
-    Transcriptomic analysis reporting a significant differential expression of {' '}
-    <strong>{ symbol}</strong> when comparing control samples with medulloblastoma samples. {' '}
-    <strong>{name}</strong> Source:{' '}
-    <Link to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis/tree/dev/analyses/" external>
-      OpenPedCan
+    mRNA expression of
+    <strong> {symbol} </strong> in pediatric
+    <strong> {name} </strong> with human adult normal tissues from GTEx. Source:{' '}
+    <Link to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis" external>
+      OpenPedCan (v10)
+    </Link>{', '}
+    <Link to="https://www.gtexportal.org/home/" external>
+      GTEx Analysis (v8)
+    </Link>{', '}
+    <Link to="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000218.v23.p8" external>
+      TARGET (v23)
+    </Link>{', '}
+    <Link to="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001436.v1.p1" external>
+      Kids First Neuroblastoma
+    </Link>{', '}
+    <Link to="https://www.ccdatalab.org/openpbta" external>
+      OpenPBTA for the CBTN (v21)
     </Link>
   </>
 );

--- a/src/sections/evidence/OpenPedCanGeneExpression/index.js
+++ b/src/sections/evidence/OpenPedCanGeneExpression/index.js
@@ -1,7 +1,7 @@
 export const definition = {
   id: 'openPedCanGeneExpression',
   name: 'OpenPedCan Gene Expression',
-  shortName: 'OP',
+  shortName: 'GX',
   hasData: ( data ) => {
     return data ? data.length > 0 : false;
   },


### PR DESCRIPTION
In this PR, I have updated "OpenPedCan Gene Expression" detail widget title, description, and source under Evidence page based on the following ticket from [CHoP's ticket](https://github.com/PediatricOpenTargets/ticket-tracker/issues/223)