### PR TITLE
PPDC-286

### DIFF
--- a/src/sections/common/OpenPedCanSomaticMutations/CnvByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticMutations/CnvByGeneTab.js
@@ -27,7 +27,7 @@ const columns = [
   { id: 'totalRelapseTumorsAlteredOverRelapseTumorsInDataset', label: 'Total relapse tumors altered/Relapse tumors in dataset', sortable: true },
   { id: 'frequencyInRelapseTumors', label: 'Frequency in relapse tumors', sortable: true },
   { id: 'geneFullName', label: 'Gene full name', sortable: true },
-  { id: 'PMTL', label: 'PMTL', sortable: true, renderCell: () => <RelevantIcon/>},
+  { id: 'PMTL', label: 'PMTL', sortable: true, renderCell: () => <RelevantIcon/>, filterValue: false},
   { id: 'OncoKBCancerGene', label: 'OncoKB cancer gene', sortable: true },
   { id: 'OncoKBOncogeneTSG', label: 'OncoKB oncogene TSG', sortable: true },
   // { id: 'EFO', label: 'EFO', sortable: true },

--- a/src/sections/common/OpenPedCanSomaticMutations/FusionByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticMutations/FusionByGeneTab.js
@@ -17,7 +17,7 @@ const columns = [
   { id: 'Disease', label: 'Disease', sortable: true,
       renderCell: ({ diseaseFromSourceMappedId, Disease }) => 
         <Link to={`/disease/${diseaseFromSourceMappedId}`}>{Disease}</Link> },
-  { id: 'PMTL', label: 'PMTL', sortable: true, renderCell: () => <RelevantIcon/>},
+  { id: 'PMTL', label: 'PMTL', sortable: true, renderCell: () => <RelevantIcon/>, filterValue: false},
   { id: 'dataset', label: 'Dataset', sortable: true, comparator: (row1, row2) => genericComparator(row1, row2, 'Dataset')},
   { id: 'totalAlterationsOverNumberPatientsInDataset', label:'Total alterations Over Patients in dataset', sortable: true},
   { id: 'frequencyInOverallDataset', label: 'Frequency in overall dataset', sortable: true},

--- a/src/sections/common/OpenPedCanSomaticMutations/FusionTab.js
+++ b/src/sections/common/OpenPedCanSomaticMutations/FusionTab.js
@@ -30,7 +30,7 @@ const columns = [
     renderCell: ({ diseaseFromSourceMappedId, Disease }) => 
       <Link to={`/disease/${diseaseFromSourceMappedId}`}>{Disease}</Link> 
   },
-  { id: 'PMTL', label: 'PMTL', sortable:true , renderCell: () => <RelevantIcon/>},
+  { id: 'PMTL', label: 'PMTL', sortable:true , renderCell: () => <RelevantIcon/>, filterValue: false},
   { id: 'dataset', label: 'Dataset', sortable:true },
   { id: 'totalAlterationsOverNumberPatientsInDataset', label: 'Total alterations Over Patients in dataset', sortable:true },
   { id: 'frequencyInOverallDataset', label: 'Frequency in overall dataset', sortable:true },

--- a/src/sections/common/OpenPedCanSomaticMutations/SnvByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticMutations/SnvByGeneTab.js
@@ -18,9 +18,8 @@ const columns = [
     renderCell: ({ geneSymbol, targetFromSourceId }) => 
         <Link to={`/target/${targetFromSourceId}`}>{geneSymbol}</Link>
   },
-  { id: 'PMTL', label: 'PMTL', sortable: true, renderCell: () => <RelevantIcon/>},
+  { id: 'PMTL', label: 'PMTL', sortable: true, renderCell: () => <RelevantIcon/>, filterValue: false},
   { id: 'dataset', label: 'Dataset', sortable: true },
-  
   { id: 'Disease', label: 'Disease', sortable: true,
     renderCell: ({ diseaseFromSourceMappedId, Disease }) => 
       <Link to={`/disease/${diseaseFromSourceMappedId}`}>{Disease}</Link>},

--- a/src/sections/common/OpenPedCanSomaticMutations/SnvByVariantTab.js
+++ b/src/sections/common/OpenPedCanSomaticMutations/SnvByVariantTab.js
@@ -15,7 +15,7 @@ const columns = [
   },
   { id: 'variantIdHg38', label: 'Variant ID hg38', sortable: true },
   { id: 'proteinChange', label: 'Protein change', sortable: true},
-  { id: 'PMTL', label: 'PMTL', sortable: true, renderCell: () => <RelevantIcon/>},
+  { id: 'PMTL', label: 'PMTL', sortable: true, renderCell: () => <RelevantIcon/>, filterValue: false},
   { id: 'dataset', label: 'Dataset', sortable: true },
   { id: 'Disease', label: 'Disease', sortable: true,
     renderCell: ({ diseaseFromSourceMappedId, Disease }) => 


### PR DESCRIPTION
In this PR, I have fixed a searching bug that was cause by the following column: "PMTL", “PedcBio PedOT oncoprint plot URL” and "PedcBio PedOT mutations plot URL". Now, a user can only search what they can visually see.

Since the "PMTL" column is an Icon across all tables, it will no longer be searchable.
