### PR TITLE
PPDC-284: Add two missing columns for SNV by Gene table

### DIFF
--- a/src/sections/common/OpenPedCanSomaticMutations/SnvByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticMutations/SnvByGeneTab.js
@@ -34,7 +34,7 @@ const columns = [
   { id: 'frequencyInPrimaryTumors', label: 'Frequency in primary tumors', sortable: true},
   { id: 'totalRelapseTumorsMutatedOverRelapseTumorsInDataset', label: 'Total relapse tumors mutated Over Relapse tumors in dataset', sortable: true},
   { id: 'frequencyInRelapseTumors',  label: 'Frequency in relapse tumors', sortable: true },
-  { id: 'OncoKBCancerGene', label: 'OncoKB cancer geneD', sortable: true},
+  { id: 'OncoKBCancerGene', label: 'OncoKB cancer gene', sortable: true},
   { id: 'OncoKBOncogeneTSG', label: 'OncoKB oncogene TSG', sortable: true},
   { id: 'pedcbioPedotOncoprintPlotURL', label: 'PedcBio PedOT oncoprint plot URL', 
     renderCell: ({pedcbioPedotOncoprintPlotURL}) => createExternalLink(pedcbioPedotOncoprintPlotURL, "oncoprint"),

--- a/src/sections/common/OpenPedCanSomaticMutations/SnvByGeneTab.js
+++ b/src/sections/common/OpenPedCanSomaticMutations/SnvByGeneTab.js
@@ -31,7 +31,9 @@ const columns = [
   { id: 'totalMutationsOverPatientsInDataset', label: 'Total mutations Over Patients in dataset', sortable: true },
   { id: 'frequencyInOverallDataset', label: 'Frequency in overall dataset', sortable: true },
   { id: 'totalPrimaryTumorsMutatedOverPrimaryTumorsInDataset', label: 'Total primary tumors mutated Over Primary tumors in dataset', sortable: true },
-  { id: 'frequencyInRelapseTumors', label: 'Frequency in relapse tumors', sortable: true },
+  { id: 'frequencyInPrimaryTumors', label: 'Frequency in primary tumors', sortable: true},
+  { id: 'totalRelapseTumorsMutatedOverRelapseTumorsInDataset', label: 'Total relapse tumors mutated Over Relapse tumors in dataset', sortable: true},
+  { id: 'frequencyInRelapseTumors',  label: 'Frequency in relapse tumors', sortable: true },
   { id: 'OncoKBCancerGene', label: 'OncoKB cancer geneD', sortable: true},
   { id: 'OncoKBOncogeneTSG', label: 'OncoKB oncogene TSG', sortable: true},
   { id: 'pedcbioPedotOncoprintPlotURL', label: 'PedcBio PedOT oncoprint plot URL', 
@@ -59,12 +61,15 @@ const dataDownloaderColumns = [
   { id: 'totalMutationsOverPatientsInDataset' },
   { id: 'frequencyInOverallDataset' },
   { id: 'totalPrimaryTumorsMutatedOverPrimaryTumorsInDataset' },
+  { id: 'frequencyInPrimaryTumors' },
+  { id: 'totalRelapseTumorsMutatedOverRelapseTumorsInDataset' },
   { id: 'frequencyInRelapseTumors' },
   { id: 'OncoKBCancerGene' },
   { id: 'OncoKBOncogeneTSG' },
   { id: 'pedcbioPedotOncoprintPlotURL' },
   { id: 'pedcbioPedotMutationsPlotURL' },
 ]
+
 function SnvByGeneTab({data, dataDownloaderFileStem}) {
   return (
     <Grid container>


### PR DESCRIPTION
In this PR, two missing columns ("Frequency in primary tumors" and
"Total relapse tumors mutated Over Relapse tumors in dataset") are added to SNV by Gene table under OpenPedCan Somatic Mutations (SM) widget for both Target & Evidence Page