### PR TITLE
PPDC-350 (captionLabel)

### DIFF
--- a/src/components/Table/DataDownloader.js
+++ b/src/components/Table/DataDownloader.js
@@ -109,7 +109,7 @@ const styles = makeStyles({
   },
 });
 
-function DataDownloader({ columns, rows, fileStem }) {
+function DataDownloader({ columns, rows, fileStem, captionLabel="Download table as" }) {
   const [downloading, setDownloading] = useState(false);
   const classes = styles();
 
@@ -147,7 +147,7 @@ function DataDownloader({ columns, rows, fileStem }) {
     <>
       <Grid container alignItems="center" justify="flex-end" spacing={1}>
         <Grid item>
-          <Typography variant="caption">Download table as</Typography>
+          <Typography variant="caption">{captionLabel}</Typography>
         </Grid>
         <Grid item>
           <Button

--- a/src/sections/common/OpenPedCanGeneExpression/Body.js
+++ b/src/sections/common/OpenPedCanGeneExpression/Body.js
@@ -104,7 +104,7 @@ function Body({ definition, id, label, getData, getPlot, Description, entity, fi
               {tab === 'linear' ? (
                 <>
                   <Grid container>
-                    <DataDownloader rows={json} columns={columns} fileStem={fileStem}/>
+                    <DataDownloader rows={json} columns={columns} fileStem={fileStem} captionLabel="Download data as"/>
                     <Grid item xs={12} style={{overflow: 'auto'}}>
                       <img src={`data:image/png;base64,${linearPlot}`}
                         width={imageWidth} height={imageHeight} alt={`${imageAlt} TPM boxplot (Linear)`} />
@@ -116,12 +116,12 @@ function Body({ definition, id, label, getData, getPlot, Description, entity, fi
               {tab === 'log10' ? (
                 <>
                   <Grid container>
-                    <DataDownloader rows={json} columns={columns} fileStem={fileStem}/>
+                    <DataDownloader rows={json} columns={columns} fileStem={fileStem} captionLabel="Download data as"/>
                     <Grid item xs={12} style={{overflow: 'auto'}}>
                       <img src={`data:image/png;base64,${log10Plot}`}
                       width={imageWidth} height={imageHeight} alt={`${imageAlt} TPM boxplot (Lag10)`} />
                     </Grid>
-                </Grid>
+                  </Grid>
                 </>
               ) : null}
             </>


### PR DESCRIPTION
In this PR:
-	A new prop called “captionLabel” is added to “components/Table/DataDownloader” to allow for users to customize the “Download table as” text found on the top right corner of widgets that allow user to download the data.
-	Updated “OpenPedCan Gene Expression” widget text from “Download table as” to “Download data as”.

Related Ticket: PPDC-350