### PR TITLE
PPDC-385 (Update footer Title)

### DIFF
--- a/src/components/NCIFooter/Footer.js
+++ b/src/components/NCIFooter/Footer.js
@@ -185,12 +185,12 @@ const styles = () => ({
   nciFooterTitle: {
     fontFamily: 'Montserrat', 
     fontWeight: 'bold', 
-    fontSize: '25pt', 
-    lineHeight: '26pt', 
+    fontSize: '25px', 
+    lineHeight: '26px', 
     color: '#fff'
   },
   nihFooterTitle: {
-    fontSize: '16pt', 
+    fontSize: '16px', 
     display: 'block'
   }
 });

--- a/src/components/NCIFooter/Footer.js
+++ b/src/components/NCIFooter/Footer.js
@@ -182,17 +182,30 @@ const styles = () => ({
       width: 'calc((100vw)/4)',
     },
   },
+  nciFooterTitle: {
+    fontFamily: 'Montserrat', 
+    fontWeight: 'bold', 
+    fontSize: '25pt', 
+    lineHeight: '26pt', 
+    color: '#fff'
+  },
+  nihFooterTitle: {
+    fontSize: '16pt', 
+    display: 'block'
+  }
 });
 
 const Footer = ({ classes, data }) => (
   <div className={classes.footerRoot}>
     <div className={classes.footerComponent}>
       <div className={cn(classes.footerRow,classes.padding20)}>
-        <div className={
-            cn(classes.footerRowSection, classes.footerNciColumn, classes.marginRight40)
-  }
-        >
-          {data.footerLogoHyperlink
+        <div>
+          <h1 NCIFooterTitle className={classes.nciFooterTitle}>
+            National Cancer Institute
+            <span className={classes.nihFooterTitle} > at the National Institutes of Health</span>
+          </h1>
+       
+         {/*} {data.footerLogoHyperlink
             ? (
               <RouteLinks to={data.footerLogoHyperlink} className={classes.nciLogo}>
                 <img
@@ -207,7 +220,7 @@ const Footer = ({ classes, data }) => (
                 alt={data.footerLogoAltText}
                 className={classes.nciLogo}
               />
-            )}
+            )}*/}
         </div>
         { data.link_sections.slice(0, 3).map((linkSection) => (
           <div className={classes.footerRowSectionLinks}>

--- a/src/components/NCIFooter/Footer.js
+++ b/src/components/NCIFooter/Footer.js
@@ -189,7 +189,7 @@ const styles = () => ({
     lineHeight: '26px', 
     color: '#fff'
   },
-  nihFooterTitle: {
+  nciFooterSubTitle: {
     fontSize: '16px', 
     display: 'block'
   }
@@ -200,27 +200,10 @@ const Footer = ({ classes, data }) => (
     <div className={classes.footerComponent}>
       <div className={cn(classes.footerRow,classes.padding20)}>
         <div>
-          <h1 NCIFooterTitle className={classes.nciFooterTitle}>
-            National Cancer Institute
-            <span className={classes.nihFooterTitle} > at the National Institutes of Health</span>
+          <h1 className={classes.nciFooterTitle}>
+            {data.footerTitle} 
+            <span className={classes.nciFooterSubTitle}> {data.footerSubTitle} </span>
           </h1>
-       
-         {/*} {data.footerLogoHyperlink
-            ? (
-              <RouteLinks to={data.footerLogoHyperlink} className={classes.nciLogo}>
-                <img
-                  src={data.footerLogoImage}
-                  alt={data.footerLogoAltText}
-                  id="footer_logo_image"
-                />
-              </RouteLinks>
-            ) : (
-              <img
-                src={data.footerLogoImage}
-                alt={data.footerLogoAltText}
-                className={classes.nciLogo}
-              />
-            )}*/}
         </div>
         { data.link_sections.slice(0, 3).map((linkSection) => (
           <div className={classes.footerRowSectionLinks}>

--- a/src/components/NCIFooter/index.js
+++ b/src/components/NCIFooter/index.js
@@ -4,9 +4,8 @@ import Footer from './Footer';
 
 const FooterData = {
   bg: '#325068',
-  footerLogoImage: 'https://raw.githubusercontent.com/CBIIT/bento-frontend/master/src/assets/footer/FNL_logo.png',
-  footerLogoAltText: 'Footer Logo',
-  footerLogoHyperlink: 'https://frederick.cancer.gov/',
+  footerTitle: 'National Cancer Institute',
+  footerSubTitle: 'at the National Institutes of Health',
   footerStaticText: 'NIH … Turning Discovery Into Health®',
    version: "mvp1",
   BEversion: "mvp1",


### PR DESCRIPTION
In this PR, the footer has been updated. Previously, there was a logo of "Frederick National laboratory for Cancer Research" that take users out to https://frederick.cancer.gov/. Now, it's replaced by a simple text that says "National Cancer Institute at the National Institutes of Health"

Related Ticket: PPDC-385