### PR TITLE
PPDC-351

### DIFF
--- a/src/sections/common/OpenPedCanGeneExpression/Body.js
+++ b/src/sections/common/OpenPedCanGeneExpression/Body.js
@@ -69,7 +69,7 @@ function Body({ definition, id, label, getData, getPlot, Description, entity, fi
     { id: 'GTEx_tissue_subgroup', exportLabel: 'gtexTissueSubgroup' },
     { id: 'EFO' },
     { id: 'MONDO' },
-    { id: 'GTEx_tissue_subgroup_UBERON' },
+    { id: 'GTEx_tissue_subgroup_UBERON', exportLabel: 'gtexTissueSubgroupUberon' },
     { id: 'TPM_mean' },
     { id: 'TPM_sd' },
     { id: 'TPM_min' },

--- a/src/sections/common/OpenPedCanGeneExpression/Body.js
+++ b/src/sections/common/OpenPedCanGeneExpression/Body.js
@@ -66,7 +66,7 @@ function Body({ definition, id, label, getData, getPlot, Description, entity, fi
     { id: 'PMTL' },
     { id: 'Dataset' },
     { id: 'Disease' },
-    { id: 'GTEx_tissue_subgroup' },
+    { id: 'GTEx_tissue_subgroup', exportLabel: 'gtexTissueSubgroup' },
     { id: 'EFO' },
     { id: 'MONDO' },
     { id: 'GTEx_tissue_subgroup_UBERON' },


### PR DESCRIPTION
In this PR:

- OpenPedCan Gene Expression (GX) export file has been updated based on the configuration file created in ppdc-config repo here:  https://github.com/CBIIT/ppdc-config/pull/6
- Currently, the Config file is controlling the order in which the columns exist and what the column headers are for GX export file.
- Since the order and most of the column header are already in place, the following code modification is made to close the gap difference from the config file. 

      o	Rename “gtExTissueSubgroup” to “gtexTissueSubgroup”
      o	Rename “gtExTissueSubgroupUberon” to “gtexTissueSubgroupUberon”

Related Ticket: PPDC-351