### PR TITLE
PPDC-390 (fix: default tab for SA widget )

### DIFF
--- a/src/sections/common/OpenPedCanSomaticAlterations/Body.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/Body.js
@@ -10,13 +10,14 @@ import SnvByVariantTab from './SnvByVariantTab';
 import CnvByGeneTab from './CnvByGeneTab';
 import FusionByGeneTab from './FusionByGeneTab';
 import FusionTab from './FusionTab';
+import { getSADefaultTab } from './utils'
 
-function Body({ definition, id, label, entity, variables, BODY_QUERY, Description, dataDownloaderFileStem}) {
+function Body({ definition, id, label, entity, variables, BODY_QUERY, summaryRequest, Description, dataDownloaderFileStem}) {
 
   const request = useQuery(BODY_QUERY, {
     variables: { ...variables, size: 9999 },
   });
-  const defaultTab = "snvByGene";
+  const defaultTab = getSADefaultTab(summaryRequest.data);
   const [tab, setTab] = useState(defaultTab);
 
   const handleChangeTab = (_, tab) => {

--- a/src/sections/common/OpenPedCanSomaticAlterations/utils.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/utils.js
@@ -21,3 +21,20 @@ export const renderPMTLCell = (pmtlText) => {
   
 }
 
+// return a default Tab that has available data
+export const getSADefaultTab = (data) => {
+  let defaultTab = "snvByGene"
+  if (data) {
+    const {snvByGene, snvByVariant, cnvByGene, fusionByGene} = data;
+    if (snvByGene && snvByGene.count === 0 && snvByVariant.count !== 0) {
+      defaultTab = "snvByVariant"
+    } else if (snvByVariant && snvByVariant.count === 0 && cnvByGene.count !== 0) {
+      defaultTab = "cnvByGene"
+    } else if (cnvByGene && cnvByGene.count === 0 && fusionByGene.count !== 0) {
+      defaultTab = "fusionByGene"
+    } else if (fusionByGene && fusionByGene.count === 0) {
+      defaultTab = "fusion"
+    }
+  }
+  return defaultTab;
+}

--- a/src/sections/common/OpenPedCanSomaticAlterations/utils.js
+++ b/src/sections/common/OpenPedCanSomaticAlterations/utils.js
@@ -25,14 +25,16 @@ export const renderPMTLCell = (pmtlText) => {
 export const getSADefaultTab = (data) => {
   let defaultTab = "snvByGene"
   if (data) {
-    const {snvByGene, snvByVariant, cnvByGene, fusionByGene} = data;
-    if (snvByGene && snvByGene.count === 0 && snvByVariant.count !== 0) {
+    const {snvByGene, snvByVariant, cnvByGene, fusionByGene, fusion} = data;
+    if (snvByGene && snvByGene.count !== 0) {
+      defaultTab = "snvByGene"
+    } else if (snvByVariant && snvByVariant.count !== 0) {
       defaultTab = "snvByVariant"
-    } else if (snvByVariant && snvByVariant.count === 0 && cnvByGene.count !== 0) {
+    } else if (cnvByGene && cnvByGene.count !== 0) {
       defaultTab = "cnvByGene"
-    } else if (cnvByGene && cnvByGene.count === 0 && fusionByGene.count !== 0) {
+    } else if (fusionByGene && fusionByGene.count !== 0) {
       defaultTab = "fusionByGene"
-    } else if (fusionByGene && fusionByGene.count === 0) {
+    } else if (fusion && fusion.count !== 0) {
       defaultTab = "fusion"
     }
   }

--- a/src/sections/evidence/OpenPedCanSomaticAlterations/Body.js
+++ b/src/sections/evidence/OpenPedCanSomaticAlterations/Body.js
@@ -4,12 +4,17 @@ import { loader } from 'graphql.macro';
 import { Body as OpenPedCanSomaticAlterationsBody } from '../../common/OpenPedCanSomaticAlterations';
 import Description from './Description';
 
+import usePlatformApi from '../../../hooks/usePlatformApi';
+import Summary from './Summary';
+
 const SOMATIC_ALTERATIONS_QUERY = loader('./SomaticAlterationsQuery.gql');
 
 function Body({ definition, id, label }) {
   const { ensgId: ensemblId, efoId } = id;
   const variables = { ensemblId, efoId }
   const dataDownloaderFileStem = `OpenPedCanSomaticAlterations-${ensemblId}-${efoId}`
+
+  const summaryRequest = usePlatformApi(Summary.fragments.evidenceSomaticAlterationsSummary)
   return (
     <OpenPedCanSomaticAlterationsBody 
       definition={definition}
@@ -18,6 +23,7 @@ function Body({ definition, id, label }) {
       entity="evidence"
       variables={variables}
       BODY_QUERY={SOMATIC_ALTERATIONS_QUERY}
+      summaryRequest={summaryRequest}
       Description={Description}
       dataDownloaderFileStem={dataDownloaderFileStem}
     />

--- a/src/sections/target/OpenPedCanSomaticAlterations/Body.js
+++ b/src/sections/target/OpenPedCanSomaticAlterations/Body.js
@@ -3,10 +3,14 @@ import { loader } from 'graphql.macro';
 
 import { Body as OpenPedCanSomaticAlterationsBody} from '../../common/OpenPedCanSomaticAlterations';
 import Description from './Description';
+import usePlatformApi from '../../../hooks/usePlatformApi';
+import Summary from './Summary';
 
 const SOMATIC_ALTERATIONS_QUERY = loader('./SomaticAlterationsQuery.gql');
 
 function Body({ definition, id, label: symbol}) {
+  const summaryRequest = usePlatformApi(Summary.fragments.targetSomaticAlterationsSummary)
+  
   const variables = { ensemblId: id };
   const dataDownloaderFileStem = `OpenPedCanSomaticAlterations-${id}`
   return (
@@ -17,6 +21,7 @@ function Body({ definition, id, label: symbol}) {
       entity="target"
       variables={variables}
       BODY_QUERY={SOMATIC_ALTERATIONS_QUERY}
+      summaryRequest={summaryRequest}
       Description={Description}
       dataDownloaderFileStem={dataDownloaderFileStem}
 


### PR DESCRIPTION
In this PR:

The default tab for OpenPedCan Somatic Alterations (SA) widget under Target and Evidence Page has been fix to not allow disabled tab as default tab. With the current fix, default tab will always have data.

Related ticket: PPDC-390