### PR TITLE
PPDC-406

### DIFF
--- a/src/components/NCIFooter/index.js
+++ b/src/components/NCIFooter/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Footer from './Footer';
-
+import { contact } from '../../constants';
 
 const FooterData = {
   bg: '#325068',
@@ -22,6 +22,10 @@ const FooterData = {
           text: 'Policies',
           link: 'https://www.cancer.gov/global/web/policies',
           title: 'link to NCI policies',
+        },
+        {
+          text: 'Contact MTP',
+          link: `mailto:${contact.email}`
         },
         {
           text: 'Disclaimer',

--- a/src/constants.js
+++ b/src/constants.js
@@ -297,3 +297,8 @@ export const studySourceMap = {
   SAIGE: 'UK Biobank',
   NEALE: 'UK Biobank',
 };
+
+export const contact = {
+  email: 'ncichildhoodcancerdatainitiative@mail.nih.gov'
+}
+

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -23,7 +23,9 @@ import UnspecifiedIcon from '../../components/RMTL/UnspecifiedIcon';
 
 import externalIcon from '../../assets/about/About-ExternalLink.svg';
 import Infographic from '../../assets/about/Infographic.png'
+import classNames from 'classnames';
 
+import { contact } from '../../constants';
 const useStyles = makeStyles(theme => ({
 
   molecularTargetC: {
@@ -134,7 +136,18 @@ const useStyles = makeStyles(theme => ({
     flex: 1,
     padding: '12px 17px 17px 14px',
     borderLeft: '1px solid #2188D8' 
-  }
+  },
+
+  base: {
+    fontSize: 'inherit',
+    textDecoration: 'none',
+  },
+  baseDefault: {
+    color: theme.palette.primary.main,
+    '&:hover': {
+      color: theme.palette.primary.dark,
+    },
+  },
 }));
 
 const AboutView = ({ data }) => {
@@ -155,6 +168,7 @@ const AboutView = ({ data }) => {
 
     }
   )
+  const contactEmail = `mailto:${contact.email}`
 
   const showHideContent = (id) => {
     const newResult = !showHide[id]
@@ -511,6 +525,14 @@ const AboutView = ({ data }) => {
 
         <Typography paragraph>
           As the project matures, new pediatric cancer data and additional functionality will be added to the Molecular Targets Platform.
+        </Typography>
+
+        <Typography paragraph>
+     
+          <a className={classNames(classes.base, classes.baseDefault)} href={contactEmail}>
+            Contact {' '}
+          </a> 
+          the Molecular Targets Platform to get more information.
         </Typography>
 
       </Grid>


### PR DESCRIPTION
In this PR, the contact email to MTP is included in the following part of the application:

- Added "_Contact MTP_" after "_Policies_" in **Footer**
- Added "_Contact_ the Molecular Targets Platform to get more information." with hyperlink on the word "Contact" in **About Page** under "The Molecular Targets Platform" section 


Once User click on "Contact" and "Contact MTP", mail link to **ncichildhoodcancerdatainitiative@mail.nih.gov** should open
