### PR TITLE
Fix: Scrolling from Summary to Detail Widget (PPDC-389)

### DIFF
--- a/src/components/Summary/SummaryItem.js
+++ b/src/components/Summary/SummaryItem.js
@@ -25,6 +25,7 @@ function SummaryItem({ definition, request, renderSummary, subText }) {
       duration: 500,
       delay: 100,
       smooth: true,
+      offset: -243, // CHANGE MADE: to scroll back -243 px 
     });
   };
 


### PR DESCRIPTION
In this PR, Scrolling from Summary to Detail Widget has been fixed. Before, the title and some part of the body of the detail widget have been covered. Now, the defect has been fixed and scrolling from summary widget ends at the start of every detail widget.

Related Ticket: PPDC-389