### PR TITLE
PPDC-397

### DIFF
--- a/src/components/RMTLTable.js
+++ b/src/components/RMTLTable.js
@@ -444,19 +444,17 @@ class OtTableRF extends Component {
               </div>
             </PlotContainerSection>
           ) : null}
-         {paginationPosition === "BOTTOM" ? (
-            <TablePagination
-              component="div"
-              count={serverSide ? totalRowsCount : data.length}
-              onPageChange={this.handleChangePage}
-              page={page}
-              rowsPerPage={pageSize}
-              rowsPerPageOptions={rowsPerPageOptions} // CHANGE MADE; Previously was rowsPerPageOptions={[]}
-              ActionsComponent={TablePaginationActions}
-              onChangeRowsPerPage={this.handleChangeRowsPerPage} // CHANGE MADE; Previously did not exist
-            />
-          ) : null}
-          </PlotContainerSection>
+          <TablePagination
+            component="div"
+            count={serverSide ? totalRowsCount : data.length}
+            onPageChange={this.handleChangePage}
+            page={page}
+            rowsPerPage={pageSize}
+            rowsPerPageOptions={rowsPerPageOptions} // CHANGE MADE; Previously was rowsPerPageOptions={[]}
+            ActionsComponent={TablePaginationActions}
+            onChangeRowsPerPage={this.handleChangeRowsPerPage} // CHANGE MADE; Previously did not exist
+          />
+        </PlotContainerSection>
       </PlotContainer>
     );
   }


### PR DESCRIPTION
In this PR: The Table pagination position located under the Pediatric Cancer Data Navigation page has been updated so that it can be on the top and bottom of the Table.