### PR TITLE
PPDC-395(update text that direct user to Pediatric Cancer Data Navigation Page)

### DIFF
--- a/src/pages/DiseasePage/ClassicAssociations.js
+++ b/src/pages/DiseasePage/ClassicAssociations.js
@@ -36,10 +36,10 @@ function ClassicAssociations({ efoId, name }) {
         </Typography>
       </Grid>
       <Grid item xs={12} md={8}>
-        <Typography variant="h6">
+        <Typography variant='h6'>
           {data ? (
             <>
-            <span style={{fontSize: '15px'}}>Pediatric Cancer Data is not yet part of these results. Please use </span> {' '} 
+              <span style={{fontSize: '16px'}}>Additional pediatric cancer data may be found by using the search tool on the </span> {' '} 
               <Link to={{
                 pathname: "/pediatric-cancer-data-navigation",
                 state: {
@@ -47,9 +47,9 @@ function ClassicAssociations({ efoId, name }) {
                   'disease': name
                 }
               }}>
-                <span style={{fontSize: '16px'}}>Pediatric Cancer Data Navigation</span>
+                <span style={{fontSize: '16px'}}><b>Pediatric Cancer Data Navigation</b></span>
               </Link> {' '}
-              <span style={{fontSize: '15px'}}>to search for pediatric cancer data.</span>
+              <span style={{fontSize: '16px'}}>page.</span>
             </>
           ) : (
             <></>

--- a/src/pages/TargetPage/ClassicAssociations.js
+++ b/src/pages/TargetPage/ClassicAssociations.js
@@ -57,10 +57,10 @@ function ClassicAssociations({ ensgId, symbol }) {
         </Typography>
       </Grid>{' '}
       <Grid item xs={12} md={8}>
-        <Typography variant="h6">
+        <Typography variant='h6'>
           {data ? (
             <>
-            <span style={{fontSize: '15px'}}>Pediatric Cancer Data is not yet part of these results. Please use </span> {' '} 
+              <span style={{fontSize: '16px'}}>Additional pediatric cancer data may be found by using the search tool on the </span> {' '} 
               <Link to={{
                 pathname: "/pediatric-cancer-data-navigation",
                 state: {
@@ -68,9 +68,9 @@ function ClassicAssociations({ ensgId, symbol }) {
                   'geneSymbol': symbol
                 }
               }}>
-                <span style={{fontSize: '16px'}}>Pediatric Cancer Data Navigation</span>
+                <span style={{fontSize: '16px'}}><b>Pediatric Cancer Data Navigation</b></span>
               </Link> {' '}
-              <span style={{fontSize: '15px'}}>to search for pediatric cancer data.</span>
+              <span style={{fontSize: '16px'}}>page.</span>
             </>
           ) : (
             <></>


### PR DESCRIPTION
In this PR, the content that direct user to the Pediatric Cancer Data Navigation Page have been updated under both the Target and Disease associated page

Text update is: "Additional pediatric cancer data may be found by using the search tool on the [_**Pediatric Cancer Data Navigation**_] page."