### PR TITLE
PPDC-422(Design Update for Pediatric Cancer Data Navigation Page)

### DIFF
--- a/src/pages/PedCancerDataNavPage/EntitySelect.js
+++ b/src/pages/PedCancerDataNavPage/EntitySelect.js
@@ -20,19 +20,31 @@ const customStyle = {
   }),
   singleValue: (provided, state) => ({
     ...provided,
-    fontSize: '16px'
+    fontSize: '16px',
+    // border: '1px solid black',
+    margin: '0px',
+    padding: '0px'
   }),
   input: (provided, state) => ({
     ...provided,
     margin: "28px 0px",
-    borderBottom: '1px solid black'
+    borderBottom: '1px solid black',
+    paddingTop: '1px',
   }),
   control: (styles) => ({
     ...styles,
     border: 'none',
     // This line disable the blue border
     boxShadow: 'none'
+  }),
+  clearIndicator: () => ({
+    borderBottom: '1px solid black',
+  }),
+  valueContainer: (provided) => ({
+    ...provided,
+    paddingRight: 0,
   })
+
 }
 
 const getDiseaseOptions = () => {
@@ -80,7 +92,11 @@ function PedSearch({setInputValue, inputValue, entity="disease", defaultOptions,
             : <components.ClearIndicator {...props}></components.ClearIndicator> 
   }
   const DropdownIndicator = props => {
-    return !props?.selectProps?.value?.value?.length ? <Search /> : null
+    return !props?.selectProps?.value?.value?.length 
+              ? <div style={{ borderBottom: '1px solid black', marginBottom: '4px', paddingRight: '4px'}}>
+                  <Search style={{}}/>
+                </div>
+              : null
   }
   const getTargetOptions = () => {
     const options = []

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -127,7 +127,7 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: "white",
   },
   entityNameItem: {
-    padding: '20px',
+    padding: '20px 2px 20px 20px',
     fontSize: '16px',
     fontWeight: 'bold'
   },
@@ -155,7 +155,7 @@ const useStyles = makeStyles(theme => ({
   },
   "@media (min-width: 1200px)": {
     geneSymbolSelectItem: {
-      paddingRight: '25px'
+      paddingRight: '15px'
     },
   },
   /*       Responsive      */

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -222,7 +222,7 @@ function CHoPPage() {
         getData({ variables: { disease: inputSanitize(disease), 
             geneSymbol: inputSanitize(geneSymbol) } });
         setTargetForInfo(geneSymbol)
-        setDiseaseInputValue(disease)
+        setDiseaseForInfo(disease)
       }
     },
     [disease, firstLoad, geneSymbol, getData]
@@ -267,9 +267,8 @@ function CHoPPage() {
 
   const resultInfoObj = () => {
     const searchOnlyForTarget = isEmpty(diseaseForInfo) && !isEmpty(targetForInfo)
-    const searchOnlyForDisease = !isEmpty(diseaseForInfo) && isEmpty(targetForInfo)
+    const searchOnlyForDisease = isEmpty(targetForInfo) && !isEmpty(diseaseForInfo) 
     const searchForBoth = !isEmpty(diseaseForInfo) && !isEmpty(targetForInfo)
-
     return {
       target: searchOnlyForTarget,
       disease: searchOnlyForDisease,

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -87,13 +87,16 @@ function getRows(downloadData) {
   });
   return rows;
 }
+const siteBlue = '#3488c8'
+const generalTextColor = '#04599a'
+const generalBackGroundColor = '#CDE9FF'
 
 const useStyles = makeStyles(theme => ({
   gridContainer: {
     margin: '170px 0 0 0',
     padding: '50px 50px 60px 50px',
-    color: '#04599a',
-    backgroundColor: "#CDE9FF",
+    color: generalTextColor,
+    backgroundColor: generalBackGroundColor,
     fontSize: '16px'
   },
 
@@ -116,10 +119,10 @@ const useStyles = makeStyles(theme => ({
     transition: "all 150ms ease",
     border: "none",
     cursor: "pointer",
-    backgroundColor: "#3489ca",
+    backgroundColor: siteBlue,
     color: "white", 
     "&:hover": {
-      color: "#3489ca"
+      color: siteBlue
     },
   },
 
@@ -152,7 +155,7 @@ const useStyles = makeStyles(theme => ({
   },
   resultHeader: {
     marginTop: '50px',
-    color: '#04599a',
+    color: 'generalTextColor',
   },
   resultTable: {
     marginTop: '50px',

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -107,7 +107,7 @@ const useStyles = makeStyles(theme => ({
     fontWeight: 'bold',
   },
   subHeader: {
-    color: 'black'
+    color: '#5c5f5e'
   },
 
   /*****          Search          *****/
@@ -313,20 +313,28 @@ function CHoPPage() {
         </Grid>
       </Grid>
 
+      {/*     First Section (Search/Info)    */}
       <Grid container direction="row" justifyContent="center" alignItems="center" className={classes.gridContainer}>
-        {/*     Header    */}
-        <Grid item xs={12} md={10} lg={9} xl={8} className={classes.headerContainer}>
-          <Typography className={classes.header} variant="h5" align="center" component="h1" paragraph>
-            Pediatric Cancer Data Navigation
-          </Typography>
-
-          <Typography component="p" align="center" paragraph className={classes.subHeader} >
-            Search for a <b>Target</b>, <b>Disease</b>, or <b>both</b> to navigate our dataset 
-            containing <b>{NUMBER_OF_TARGET}</b> Targets and <b>{NUMBER_OF_DISEASE}</b> Diseases 
-            across <b>{NUMBER_OF_EVIDENCE}</b> Evidence Pages.
-          </Typography>
+        {/*     Header   */}
+        <Grid container item xs={12} className={classes.headerContainer}>
+          <Grid item xs={12}>
+            <Typography className={classes.header} variant="h5" align="center" component="h1" paragraph>
+              Pediatric Cancer Data Navigation
+            </Typography>
+          </Grid>
+          {/*   Sub Header  */}
+          <Grid container item xs={12} direction="row" justifyContent="center" alignItems="center">
+            <Grid container item alignItems="center" style={{width: '600px'}}> 
+              <Grid item xs>
+                <Typography component="p" align="center" paragraph className={classes.subHeader} >
+                Search for a <b>Target</b>, <b>Disease</b>, or <b>both</b> to navigate our dataset 
+                containing <b>{NUMBER_OF_TARGET}</b> Targets and <b>{NUMBER_OF_DISEASE}</b> Diseases 
+                across <b>{NUMBER_OF_EVIDENCE}</b> Evidence Pages.
+              </Typography>
+              </Grid>
+            </Grid>
+          </Grid>
         </Grid>
-
         {/*    Search    */}
         <Grid container alignItems="center" justifyContent='center' item xs={12} md={11} lg={10} xl={9}>
           {/*   Gene Symbol   */}
@@ -385,7 +393,8 @@ function CHoPPage() {
         </Grid>
 
       </Grid>
-      {/*     Result     */}
+      
+      {/*     Second Section (Result)    */}
       { displayTable ?
         <Grid container direction="row" justifyContent="center" alignItems="center" className={classes.result}>
           {/*     Result Header     */}

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -125,6 +125,11 @@ const useStyles = makeStyles(theme => ({
 
   entityContainer: {
     backgroundColor: "white",
+    minWidth: '360px',
+    maxWidth: '441px'
+  },
+  searchContainer:{
+    maxWidth: '92px'
   },
   entityNameItem: {
     padding: '20px 2px 20px 20px',
@@ -159,6 +164,20 @@ const useStyles = makeStyles(theme => ({
     },
   },
   /*       Responsive      */
+  "@media (max-width: 913px)": {
+    searchContainer: {
+      minWidth: '300px',
+      marginTop: '20px'
+    },
+  },
+  "@media (max-width: 821px)": {
+    entityContainer: {
+      marginTop: '20px'
+    },
+    geneSymbolSelectItem: {
+      paddingRight: '25px'
+    }
+  },
   "@media (max-width: 650px)": {
     gridContainer: {
       padding: '50px 10px 60px 10px',
@@ -166,12 +185,7 @@ const useStyles = makeStyles(theme => ({
     headerContainer: {
       marginTop: '100px'
     },
-    entityContainer: {
-      minWidth: '300px'
-    },
-    entityNameItem: {
-      paddingRight: '0px'
-    },
+
     geneSymbolSelectItem: {
       paddingRight: '25px' 
     }
@@ -334,10 +348,10 @@ function CHoPPage() {
             </Grid>
           </Grid>
         </Grid>
-        {/*    Search    */}
-        <Grid container alignItems="center" justifyContent='center' item xs={12} md={11} lg={10} xl={9}>
+        {/*    Search    xs={10} sm={7} md={12} lg={10} xl={9} */} 
+        <Grid container justifyContent='center' item xs={12}>
           {/*   Gene Symbol   */}
-          <Grid container item alignItems="center" sm={5} className={classes.entityContainer}> 
+          <Grid container item alignItems="center" xs className={classes.entityContainer}> 
             <Grid item className={classes.entityNameItem}> Gene Symbol: </Grid>
             <Grid item xs className={classes.geneSymbolSelectItem}>
               <EntitySelect inputValue={targetInputValue} setInputValue={setTargetInputValue}
@@ -345,16 +359,18 @@ function CHoPPage() {
             </Grid>
           </Grid>
           {/*   Disease   */}
-          <Grid container item sm={5} alignItems="center"  className={classes.entityContainer}> 
+          <Grid container item  alignItems="center" xs className={classes.entityContainer}> 
             <Grid item className={classes.entityNameItem}> Disease: </Grid>
             <Grid item xs className={classes.diseaseSelectItem}>
               <EntitySelect entity="disease" inputValue={diseaseInputValue} setInputValue={setDiseaseInputValue} />
             </Grid>
-          </Grid> 
-          <Grid item >
-            <Button className={classes.searchButton} onClick={handleOnClick} disabled={inputFieldAreBothEmpty}
-              variant="contained" size="large"> Search </Button>
           </Grid>
+          <Grid container item justifyContent='center' xs={12} className={classes.searchContainer}> 
+            <Grid item> 
+              <Button className={classes.searchButton} onClick={handleOnClick} disabled={inputFieldAreBothEmpty}
+              variant="contained" size="large"> Search </Button>
+            </Grid>
+          </Grid>  
         </Grid>
         <br />
         


### PR DESCRIPTION
In this PR the design for Pediatric Cancer Data Navigation Page has been update with the following:
-  Wrap the text under the title, wrap it to a second line starting at "containing 43,8880..."
- Update Sub Header/title color from black to "#5c5f5e"
- Search bar is too much wide. So it has been closely match with Hannah Design as follow:

       - Space between "Gene Symbol:" and line should be 10 px wide, apply the same rule with "Disease:"
       - Move search icons to sit on top of line, and eliminate the space it was sitting on, so space between two search criteria should be approx 35 px
       - "x" should also sit on top of line
       - make sure lines under both criteria are 275 px wide each
       - Color of search box is "#3488c8"

-Keep the rest of page as is 
