### PR TITLE
PPDC-467(Fix: Opening link in new Tab for Gene Symbol and Disease under PCDN page)

### DIFF
--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -25,7 +25,7 @@ const columns = [
       const ensemblID = row.geneEnsemblId;
       const url = '/target/' + ensemblID;
       return ensemblID !== "Symbol_Not_Found" ? 
-      ( <Link to={url}>{row.geneSymbol}</Link>):
+      ( <Link to={url} external>{row.geneSymbol}</Link>):
        (<p> {row.geneSymbol} </p>)
     },
     

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -35,7 +35,7 @@ const columns = [
     id: 'disease',
     label: 'Disease',
     renderCell: ({ EFO, disease }) => 
-      <Link to={`/disease/${EFO}`}>{disease}</Link>,
+      <Link to={`/disease/${EFO}`} external>{disease}</Link>,
     comparator: (a, b) => genericComparator(a, b, 'disease'),
   },
   {


### PR DESCRIPTION
In this PR, The links under the Pediatric Cancer Data Navigation page has been updated from opening in the same tab to a new tab. Now, Gene Symbol/Target, Disease, and the Evidence links will all open in a new tab.

Related ticket: PPDC-467