### PR TITLE
Fix naming convention issue on Nav page

### DIFF
--- a/src/pages/PedCancerDataNavPage/EntitySelect.js
+++ b/src/pages/PedCancerDataNavPage/EntitySelect.js
@@ -16,20 +16,21 @@ const customStyle = {
     ...provided,
     backgroundColor: state.isFocused ? '#ECECEC' : 'white',
     color: 'black',
+    textTransform: 'capitalize',
     fontSize: "14px"
   }),
   singleValue: (provided, state) => ({
     ...provided,
     fontSize: '16px',
-    // border: '1px solid black',
     margin: '0px',
+    textTransform: 'capitalize',
     padding: '0px'
   }),
   input: (provided, state) => ({
     ...provided,
     margin: "28px 0px",
     borderBottom: '1px solid black',
-    paddingTop: '1px',
+    paddingTop: '1px'
   }),
   control: (styles) => ({
     ...styles,


### PR DESCRIPTION
Navigate to the Pediatric Cancer Data Navigation page.
Click on the Disease drop down and scroll up and down to view the entries.
Seeing the naming convention issues of the entries.
The fix capitalize entries, name of disease follows same  naming convention. 