### PR TITLE
PPDC-482(emphasize link to PCDN page under Disease/Target Association page)

### DIFF
--- a/src/pages/DiseasePage/ClassicAssociations.js
+++ b/src/pages/DiseasePage/ClassicAssociations.js
@@ -64,7 +64,7 @@ function ClassicAssociations({ efoId, name }) {
       <Typography variant='h6' align='right'>
       {data ? (
         <>
-          <span className={classes.desPCDNText} desPCDNText>Additional pediatric cancer data may be found at:</span>
+          <span className={classes.desPCDNText}>Additional pediatric cancer data may be found at:</span>
           <div className={classes.PCDNBox}>
             <Link to={{
               pathname: PCDNUrl,

--- a/src/pages/DiseasePage/ClassicAssociations.js
+++ b/src/pages/DiseasePage/ClassicAssociations.js
@@ -1,13 +1,36 @@
 import React, { useState } from 'react';
-import { Card, CardContent, Grid, Typography } from '@material-ui/core';
+import { Card, CardContent, Grid, makeStyles, Typography } from '@material-ui/core';
 import { useQuery } from '@apollo/client';
 import { loader } from 'graphql.macro';
 
 import ClassicAssociationsTable from './ClassicAssociationsTable';
 import { Facets } from '../../components/Facets';
 import Link from '../../components/Link';
+import NavIcon from '../../assets/PediatricDataCancer-MenuBar-Icon.svg'
 
 const DISEASE_FACETS_QUERY = loader('./DiseaseFacets.gql');
+
+const useStyles = makeStyles(theme => ({
+  PCDNBox: {
+    backgroundColor: '#5CA300', 
+    minWidth: '289px',
+    height: '31px', 
+    display: 'inline-block', 
+    fontFamily: 'Inter', 
+    padding: '0px 13px'
+  },
+  PCDNText: {
+    fontSize: '16px', 
+    color: 'white', 
+    paddingLeft: '8px', 
+    position: 'relative', 
+    top: '-1px'
+  },
+  desPCDNText: {
+    fontSize: '16px',
+    marginRight: '11px',
+  },
+}))
 
 function ClassicAssociations({ efoId, name }) {
   const [aggregationFilters, setAggregationFilters] = useState([]);
@@ -20,6 +43,8 @@ function ClassicAssociations({ efoId, name }) {
   };
 
   const facetData = data?.disease?.associatedTargets.aggregations.aggs;
+  const classes = useStyles()
+  const PCDNUrl = '/pediatric-cancer-data-navigation';
 
   return (
     <Grid style={{ marginTop: '8px' }} container spacing={2}>
@@ -36,25 +61,27 @@ function ClassicAssociations({ efoId, name }) {
         </Typography>
       </Grid>
       <Grid item xs={12} md={8}>
-        <Typography variant='h6'>
-          {data ? (
-            <>
-              <span style={{fontSize: '16px'}}>Additional pediatric cancer data may be found by using the search tool on the </span> {' '} 
-              <Link to={{
-                pathname: "/pediatric-cancer-data-navigation",
-                state: {
-                  entity: 'disease',
-                  'disease': name
-                }
-              }}>
-                <span style={{fontSize: '16px'}}><b>Pediatric Cancer Data Navigation</b></span>
-              </Link> {' '}
-              <span style={{fontSize: '16px'}}>page.</span>
-            </>
-          ) : (
-            <></>
-          )}
-        </Typography>
+      <Typography variant='h6' align='right'>
+      {data ? (
+        <>
+          <span className={classes.desPCDNText} desPCDNText>Additional pediatric cancer data may be found at:</span>
+          <div className={classes.PCDNBox}>
+            <Link to={{
+              pathname: PCDNUrl,
+              state: {
+                entity: 'disease',
+                'disease': name
+              }
+            }}>
+              <img src={NavIcon} width="15px" height="15px" alt={"Navigation Icon"}/>
+              <span className={classes.PCDNText}>Pediatric Cancer Data Navigation</span>
+            </Link> {' '}
+          </div>
+        </>
+      ) : (
+        <></>
+      )}
+    </Typography>
       </Grid>{' '}
 
       <Grid item xs={12} lg={3}>

--- a/src/pages/TargetPage/ClassicAssociations.js
+++ b/src/pages/TargetPage/ClassicAssociations.js
@@ -86,7 +86,7 @@ function ClassicAssociations({ ensgId, symbol }) {
         <Typography variant='h6' align='right'>
           {data ? (
             <>
-              <span className={classes.desPCDNText} desPCDNText>Additional pediatric cancer data may be found at:</span>
+              <span className={classes.desPCDNText}>Additional pediatric cancer data may be found at:</span>
               <div className={classes.PCDNBox}>
                 <Link to={{
                   pathname: PCDNUrl,

--- a/src/pages/TargetPage/ClassicAssociations.js
+++ b/src/pages/TargetPage/ClassicAssociations.js
@@ -40,6 +40,10 @@ function ClassicAssociations({ ensgId, symbol }) {
 
   const facetData = data?.target?.associatedDiseases.aggregations.aggs;
 
+  const PCDNStyle = {
+
+  }
+
   return (
     <Grid style={{ marginTop: '8px' }} container spacing={2}>
       <Grid item xs={12} md={4}>
@@ -57,10 +61,10 @@ function ClassicAssociations({ ensgId, symbol }) {
         </Typography>
       </Grid>{' '}
       <Grid item xs={12} md={8}>
-        <Typography variant='h6'>
+        <Typography variant='h6' align='right'>
           {data ? (
             <>
-              <span style={{fontSize: '16px'}}>Additional pediatric cancer data may be found by using the search tool on the </span> {' '} 
+              <span style={{fontSize: '16px'}}>Additional pediatric cancer data may be found at: </span> {' '} 
               <Link to={{
                 pathname: "/pediatric-cancer-data-navigation",
                 state: {
@@ -70,7 +74,6 @@ function ClassicAssociations({ ensgId, symbol }) {
               }}>
                 <span style={{fontSize: '16px'}}><b>Pediatric Cancer Data Navigation</b></span>
               </Link> {' '}
-              <span style={{fontSize: '16px'}}>page.</span>
             </>
           ) : (
             <></>

--- a/src/pages/TargetPage/ClassicAssociations.js
+++ b/src/pages/TargetPage/ClassicAssociations.js
@@ -13,6 +13,7 @@ import {
   Typography,
   Tabs,
   Tab,
+  makeStyles,
 } from '@material-ui/core';
 import { useQuery } from '@apollo/client';
 
@@ -23,8 +24,30 @@ import ClassicAssociationsBubbles from './ClassicAssociationsBubbles';
 import ClassicAssociationsTable from './ClassicAssociationsTable';
 import { Facets } from '../../components/Facets';
 import Wrapper from './Wrapper';
+import NavIcon from '../../assets/PediatricDataCancer-MenuBar-Icon.svg'
 
 const TARGET_FACETS_QUERY = loader('./TargetFacets.gql');
+const useStyles = makeStyles(theme => ({
+  PCDNBox: {
+    backgroundColor: '#5CA300', 
+    minWidth: '289px',
+    height: '31px', 
+    display: 'inline-block', 
+    fontFamily: 'Inter', 
+    padding: '0px 13px'
+  },
+  PCDNText: {
+    fontSize: '16px', 
+    color: 'white', 
+    paddingLeft: '8px', 
+    position: 'relative', 
+    top: '-1px'
+  },
+  desPCDNText: {
+    fontSize: '16px',
+    marginRight: '11px',
+  },
+}))
 
 function ClassicAssociations({ ensgId, symbol }) {
   const match = useRouteMatch();
@@ -39,10 +62,9 @@ function ClassicAssociations({ ensgId, symbol }) {
   };
 
   const facetData = data?.target?.associatedDiseases.aggregations.aggs;
-
-  const PCDNStyle = {
-
-  }
+ 
+  const classes = useStyles()
+  const PCDNUrl = '/pediatric-cancer-data-navigation';
 
   return (
     <Grid style={{ marginTop: '8px' }} container spacing={2}>
@@ -64,16 +86,19 @@ function ClassicAssociations({ ensgId, symbol }) {
         <Typography variant='h6' align='right'>
           {data ? (
             <>
-              <span style={{fontSize: '16px'}}>Additional pediatric cancer data may be found at: </span> {' '} 
-              <Link to={{
-                pathname: "/pediatric-cancer-data-navigation",
-                state: {
-                  entity: 'target',
-                  'geneSymbol': symbol
-                }
-              }}>
-                <span style={{fontSize: '16px'}}><b>Pediatric Cancer Data Navigation</b></span>
-              </Link> {' '}
+              <span className={classes.desPCDNText} desPCDNText>Additional pediatric cancer data may be found at:</span>
+              <div className={classes.PCDNBox}>
+                <Link to={{
+                  pathname: {PCDNUrl},
+                  state: {
+                    entity: 'target',
+                    'geneSymbol': symbol
+                  }
+                }}>
+                  <img src={NavIcon} width="15px" height="15px" alt={"Navigation Icon"}/>
+                  <span className={classes.PCDNText}>Pediatric Cancer Data Navigation</span>
+                </Link> {' '}
+              </div>
             </>
           ) : (
             <></>

--- a/src/pages/TargetPage/ClassicAssociations.js
+++ b/src/pages/TargetPage/ClassicAssociations.js
@@ -89,7 +89,7 @@ function ClassicAssociations({ ensgId, symbol }) {
               <span className={classes.desPCDNText} desPCDNText>Additional pediatric cancer data may be found at:</span>
               <div className={classes.PCDNBox}>
                 <Link to={{
-                  pathname: {PCDNUrl},
+                  pathname: PCDNUrl,
                   state: {
                     entity: 'target',
                     'geneSymbol': symbol


### PR DESCRIPTION
In this PR:

- The Association Tab under Disease and Target has been updated to emphasis the link to Pediatric Cancer Data Navigation (PCDN) page.
- Update Descriptive text from "Additional pediatric cancer data may be found by using the search tool on the [Pediatric Cancer Data Navigation] page." to "Additional pediatric cancer data may be found at: [Pediatric Cancer Data Navigation]"

Related Ticket: PPDC-482