### PR TITLE
PPDC-498

### DIFF
--- a/src/components/RMTLTable.js
+++ b/src/components/RMTLTable.js
@@ -188,15 +188,15 @@ const tableStyles = theme => ({
 
 class OtTableRF extends Component {
   state = {
-    page: this.props.page || 0,
+    page: 0,
     sortBy: this.props.sortBy,
     order: this.props.order,
   };
 
   handleChangePage = (event, page) => {
-    const { onPageSort, pageSize, setPage } = this.props;
+    const { onPageSort, pageSize } = this.props;
     window.scrollTo(0, document.getElementById('mtp-table').offsetTop-300);
-    setPage ? setPage(page) : this.setState({page})
+    this.setState({ page })
     if (onPageSort) {
       onPageSort({ page: page, pageSize: pageSize });
     }
@@ -227,12 +227,18 @@ class OtTableRF extends Component {
   * Change the rows per page and set back the page to 0.
   */
   handleChangeRowsPerPage = event => {
-    const { onRowsPerPageChange, setPage } = this.props
+    const { onRowsPerPageChange } = this.props
     if (onRowsPerPageChange) {
       onRowsPerPageChange(event.target.value);
-      setPage ? setPage(0) : this.setState({page:0})
+      this.setState({ page: 0 })
     }
   };
+  componentDidUpdate(prevProps) {
+    // Reset to the first page if data is updated.
+    if (prevProps.data !== this.props.data ) {
+      this.setState({page: 0})
+    }
+  }
 
   render() {
     const {
@@ -256,9 +262,7 @@ class OtTableRF extends Component {
       rowsPerPageOptions = [], // Added this prop and gave option [] for existing component that do not have functionality to change the amount of row per page
       paginationPosition = "BOTTOM"
     } = this.props;
-    const { sortBy, order } = this.state;
-    const page = this.props.page || this.state.page
-
+    const { sortBy, order, page} = this.state;
     const filterRow = filters ? (
       <TableRow className={classes.tableRowFilters}>
         {columns.map(column => (

--- a/src/components/RMTLTable.js
+++ b/src/components/RMTLTable.js
@@ -188,17 +188,15 @@ const tableStyles = theme => ({
 
 class OtTableRF extends Component {
   state = {
-    page: 0,
+    page: this.props.page || 0,
     sortBy: this.props.sortBy,
     order: this.props.order,
   };
 
   handleChangePage = (event, page) => {
-    const { onPageSort, pageSize } = this.props;
+    const { onPageSort, pageSize, setPage } = this.props;
     window.scrollTo(0, document.getElementById('mtp-table').offsetTop-300);
-    this.setState({
-      page,
-    });
+    setPage ? setPage(page) : this.setState({page})
     if (onPageSort) {
       onPageSort({ page: page, pageSize: pageSize });
     }
@@ -229,13 +227,13 @@ class OtTableRF extends Component {
   * Change the rows per page and set back the page to 0.
   */
   handleChangeRowsPerPage = event => {
-    if (this.props.onRowsPerPageChange) {
-      this.props.onRowsPerPageChange(event.target.value);
-      this.setState({ page: 0 });
+    const { onRowsPerPageChange, setPage } = this.props
+    if (onRowsPerPageChange) {
+      onRowsPerPageChange(event.target.value);
+      setPage ? setPage(0) : this.setState({page:0})
     }
   };
 
-  
   render() {
     const {
       loading,
@@ -258,7 +256,9 @@ class OtTableRF extends Component {
       rowsPerPageOptions = [], // Added this prop and gave option [] for existing component that do not have functionality to change the amount of row per page
       paginationPosition = "BOTTOM"
     } = this.props;
-    const { sortBy, order, page } = this.state;
+    const { sortBy, order } = this.state;
+    const page = this.props.page || this.state.page
+
     const filterRow = filters ? (
       <TableRow className={classes.tableRowFilters}>
         {columns.map(column => (

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -237,6 +237,7 @@ function CHoPPage() {
 
   const [displayTable, setDisplayTable] = useState(false || geneSymbol.length !==0 || disease.length !==0)
   const [pageSize, setPageSize] = useState(25);
+  const [page, setPage] = useState(0)
 
   const [getData, { loading, data }] = useLazyQuery(PED_CAN_DATA_NAV_QUERY, {
     variables: { disease: diseaseInputValue, geneSymbol: targetInputValue },
@@ -290,6 +291,8 @@ function CHoPPage() {
       setDisplayTable(true)
       setTargetForInfo(targetInputValue)
       setDiseaseForInfo(diseaseInputValue)
+      // reset to the first page 
+      setPage(0)
     }
   }
 
@@ -450,6 +453,8 @@ function CHoPPage() {
                       onRowsPerPageChange={handleRowsPerPageChange}
                       rowsPerPageOptions={rowsPerPageOptions}
                       paginationPosition="TOP"
+                      page={page}
+                      setPage={setPage}
                     />
                   </Box>
                 </Paper>

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -237,7 +237,6 @@ function CHoPPage() {
 
   const [displayTable, setDisplayTable] = useState(false || geneSymbol.length !==0 || disease.length !==0)
   const [pageSize, setPageSize] = useState(25);
-  const [page, setPage] = useState(0)
 
   const [getData, { loading, data }] = useLazyQuery(PED_CAN_DATA_NAV_QUERY, {
     variables: { disease: diseaseInputValue, geneSymbol: targetInputValue },
@@ -291,13 +290,11 @@ function CHoPPage() {
       setDisplayTable(true)
       setTargetForInfo(targetInputValue)
       setDiseaseForInfo(diseaseInputValue)
-      // reset to the first page 
-      setPage(0)
     }
   }
 
   const reformatResult = result?.length !== 0 ? getRows(result?.pedCanNav.rows || []) : []
-
+  
   const resultInfoObj = () => {
     const searchOnlyForTarget = isEmpty(diseaseForInfo) && !isEmpty(targetForInfo)
     const searchOnlyForDisease = isEmpty(targetForInfo) && !isEmpty(diseaseForInfo) 
@@ -453,8 +450,6 @@ function CHoPPage() {
                       onRowsPerPageChange={handleRowsPerPageChange}
                       rowsPerPageOptions={rowsPerPageOptions}
                       paginationPosition="TOP"
-                      page={page}
-                      setPage={setPage}
                     />
                   </Box>
                 </Paper>

--- a/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
+++ b/src/pages/PedCancerDataNavPage/PedCancerDataNavPage.js
@@ -294,7 +294,7 @@ function CHoPPage() {
   }
 
   const reformatResult = result?.length !== 0 ? getRows(result?.pedCanNav.rows || []) : []
-  
+
   const resultInfoObj = () => {
     const searchOnlyForTarget = isEmpty(diseaseForInfo) && !isEmpty(targetForInfo)
     const searchOnlyForDisease = isEmpty(targetForInfo) && !isEmpty(diseaseForInfo) 


### PR DESCRIPTION
In this PR:

- Before the fix, The table was persisting the` page` state even after new data is available. With new data update, the table pagination can be out of boundary access since the page state has not reset to the first page. This will hide the new data by display an empty rows.
- Now, Table Pagination(RMTLTable) has been updated to reset to the first page once there is data update. 


Related Ticket: PPDC-498