### PR TITLE
PPDC-505 (Update Link text to PCDN under HomePage )

### DIFF
--- a/src/pages/HomePage/HomeBox.js
+++ b/src/pages/HomePage/HomeBox.js
@@ -82,7 +82,7 @@ const HomeBox = ({ children }) => {
             <img src={NavIcon} width="26px" height="27px" alt={"Navigation Icon"}/>
           </div>
           <span className={classes.PCDNTextContainer}>
-            <span className={classes.PCDNText}>Explore our Pediatric Cancer Data Navigation</span>
+            <span className={classes.PCDNText}>Explore our Pediatric Cancer Data</span>
           </span>
         </div>
       </a>

--- a/src/pages/HomePage/HomeBox.js
+++ b/src/pages/HomePage/HomeBox.js
@@ -82,7 +82,7 @@ const HomeBox = ({ children }) => {
             <img src={NavIcon} width="26px" height="27px" alt={"Navigation Icon"}/>
           </div>
           <span className={classes.PCDNTextContainer}>
-            <span className={classes.PCDNText}>Explore the Pediatric Cancer Data Navigation</span>
+            <span className={classes.PCDNText}>Explore our Pediatric Cancer Data Navigation</span>
           </span>
         </div>
       </a>


### PR DESCRIPTION
In this PR:

- HomePage has been updated. Specifically, the link text to Pediatric Cancer Data Navigation page has changed from "Explore **the** Pediatric Cancer Data Navigation" to "Explore **our** Pediatric Cancer Data" ~~Navigation"~~

Related Ticket: PPDC-505