### PR TITLE
PPDC-501(Fix: remove unneeded space from footer)

### DIFF
--- a/src/components/NCIFooter/Footer.js
+++ b/src/components/NCIFooter/Footer.js
@@ -195,8 +195,8 @@ const Footer = ({ classes, data }) => (
         <div className={classes.horizontalLine} />
       </div>
          <div className={classes.version}>
-          <div>FE Version : {data.FEversion} </div>
-          <div>BE Version : {data.BEversion} </div>
+          <div>FE Version: {data.FEversion} </div>
+          <div>BE Version: {data.BEversion} </div>
         </div>
       <div className={classes.marginTopNeg}>
       <div className={cn(classes.footerRow, classes.contentJustifyCenter)}>


### PR DESCRIPTION
In this PR, Space between a word and colon that are not needed have been removed under Footer.

Related Ticket: PPDC-501