### PR TITLE
PPDC-480 (Update background color for PCDN Nav Menu)

### DIFF
--- a/src/components/NCINavBar/NavBarView.js
+++ b/src/components/NCINavBar/NavBarView.js
@@ -137,6 +137,9 @@ const styles = () => ({
     border: '1px solid #FFFFFF',
     backgroundColor: "#4B8500",
     borderRadius: '20px',
+    '&:hover': {
+      backgroundColor: '#437503'
+    }
   }),
   activeLabelForPCDN: (props) => ({
     backgroundColor: '#437503',

--- a/src/components/NCINavBar/NavBarView.js
+++ b/src/components/NCINavBar/NavBarView.js
@@ -139,7 +139,7 @@ const styles = () => ({
     borderRadius: '20px',
   }),
   activeLabelForPCDN: (props) => ({
-    backgroundColor: '#355e00',
+    backgroundColor: '#437503',
   }),
   appBarShift: {
     paddingRight: '0px !important',


### PR DESCRIPTION
In this Pr:

- NCI Nav Menu has been updated. Specifically the Pediatric Cancer Data Navigation(PCDN) button's background color has been update from "#355e00"(darker green) to "#437503"(brighter green)
- On Hover background color to "#437503" is also included.
 