### PR TITLE
PPDC-511 (Fix: Remove OT info from EmptyPage)

### DIFF
--- a/src/pages/EmptyPage/EmptyPage.js
+++ b/src/pages/EmptyPage/EmptyPage.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import { Grid, Typography, withStyles } from '@material-ui/core';
 import {
-  faEnvelope,
   faExclamationTriangle,
-  faQuestionCircle,
-  faSearchPlus,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -15,9 +12,6 @@ const styles = theme => ({
   icon: {
     color: theme.palette.primary.main,
     marginBottom: '12px',
-  },
-  actionText: {
-    width: '150px',
   },
   suggestions: {
     width: '450px',

--- a/src/pages/EmptyPage/EmptyPage.js
+++ b/src/pages/EmptyPage/EmptyPage.js
@@ -49,47 +49,6 @@ const EmptyPage = ({ classes, children }) => {
           <Link to="/drug/CHEMBL3137343">Keytruda</Link>
         </Grid>
       </Typography>
-      <Typography gutterBottom className={classes.message}>
-        You might also want to ...
-      </Typography>
-      <Grid item container justify="center">
-        <Grid item container direction="column" md={2} alignItems="center">
-          <a href="https://platform-docs.opentargets.org/">
-            <FontAwesomeIcon
-              icon={faQuestionCircle}
-              size="3x"
-              className={classes.icon}
-            />
-          </a>
-          <Typography align="center" className={classes.actionText}>
-            Check out our documentation
-          </Typography>
-        </Grid>
-        <Grid item container direction="column" md={2} alignItems="center">
-          <a href="mailto:helpdesk@opentargets.org">
-            <FontAwesomeIcon
-              icon={faEnvelope}
-              size="3x"
-              className={classes.icon}
-            />
-          </a>
-          <Typography align="center" className={classes.actionText}>
-            Contact the Platform helpdesk
-          </Typography>
-        </Grid>
-        <Grid item container direction="column" md={2} alignItems="center">
-          <a href="mailto:helpdesk@opentargets.org">
-            <FontAwesomeIcon
-              icon={faSearchPlus}
-              size="3x"
-              className={classes.icon}
-            />
-          </a>
-          <Typography align="center" className={classes.actionText}>
-            Suggest a target, disease, or drug
-          </Typography>
-        </Grid>
-      </Grid>
     </Grid>
   );
 };


### PR DESCRIPTION
In this PR:

- EmptyPage has been updated to remove OT's information. This page is displayed after user search for something that is not in the Platform database.
- Link to "Check out our documentation.", "Contact the Platform helpdesk" and "Suggest a target, disease, or drug" are now removed from the Empty Page.

Related Ticket: PPDC-511