### PR TITLE
PPDC-514 (Dynamically download the filtered list from the PMTL table) | ...

### DIFF
--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -361,7 +361,7 @@ class PMTLPage extends Component {
                 </Lk>
                 <DataDownloader
                   tableHeaders={downloadColumns}
-                  rows={downloadRows}
+                  rows={filteredRows}
                   fileStem={`pmtl`}
                 />
                 <RMTLTable

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -17,21 +17,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { Link as Lk } from '@material-ui/core';
 
-function getDownloadRows(downloadData) {
-  const rows = [];
-  downloadData.forEach(mapping => {
-    rows.push({
-      ensemblID: mapping.Ensembl_ID,
-      targetSymbol: mapping.Approved_Symbol,
-      designation: mapping.FDA_Designation,
-      fdaClass: mapping.FDA_Class,
-      fdaTarget: mapping.FDA_Target,
-      mappingDescription: mapping.Mapping_Description,
-    });
-  });
-  return rows;
-}
-
 function getRows(downloadData) {
   const rows = [];
   downloadData.forEach(mapping => {
@@ -289,7 +274,6 @@ class PMTLPage extends Component {
   render() {
     const rows = getRows(PMTLData);
     // Download Data will be coming from getDownloadRows()
-    const downloadRows = getDownloadRows(PMTLData);
     const { filteredRows, pageSize } = this.state;
 
     const loading = false,


### PR DESCRIPTION
In this PR:

- FDA PMTL table will dynamically download the filtered list from the table. Before when a user Download the FDA PMTL table, the complete file of “512” records was being downloaded even if user already filter the table.  


Related Ticket: PPDC-514