### PR TITLE
PPDC-527 (fix: remove incomplete archive text and link) | MVP

### DIFF
--- a/src/pages/PMTLDocPage/index.js
+++ b/src/pages/PMTLDocPage/index.js
@@ -379,17 +379,6 @@ function PMTLDocPage() {
           </Grid>
 
 
-          <Grid item xs={12}>
-            <Typography paragraph>
-            To view and download previous interpretations of the PMTL 
-            and the detailed changelog, access the 
-            <Link href={hugoHgncLink} rel="noopener" target="_blank">
-                 <b> archive</b> 
-              </Link>.
-            </Typography>
-          </Grid>
-
-
           <Grid item xs={12} id="colums-description">
             <Typography variant="h4">FDA PMTL Columns</Typography>
           </Grid>


### PR DESCRIPTION
In this PR:

- A text and link that says, "To view and download previous interpretations of the PMTL and the detailed changelog, access the [archive](https://www.genenames.org/download/custom/)." under PMTL Documentation page has been removed. 