### PR TITLE
PPDC-524 (Fix: column name for FDA PMTL Downloaded file | MVP)

### DIFF
--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -178,7 +178,7 @@ function getColumns(
 }
 
 const downloadColumns = [
-  { id: 'ensemblID', label: 'Ensembl_ID' },
+  { id: 'ensemblID', label: 'ensemblID' },
   { id: 'targetSymbol', label: 'Approved_Symbol' },
   { id: 'designation', label: 'FDA_Designation' },
   { id: 'fdaClass', label: 'FDA_Class' },

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -182,7 +182,7 @@ const downloadColumns = [
   { id: 'targetSymbol', label: 'targetSymbol' },
   { id: 'designation', label: 'designation' },
   { id: 'fdaClass', label: 'fdaClass' },
-  { id: 'fdaTarget', label: 'FDA_Target' },
+  { id: 'fdaTarget', label: 'fdaTarget' },
   { id: 'mappingDescription', label: 'Mapping_Description' },
 ];
 

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -69,9 +69,9 @@ function getColumns(
       renderCell: row => {
         const ensemblID = row.ensemblID;
         const url = '/target/' + ensemblID;
-        return ensemblID !== "Symbol_Not_Found" ? 
-        ( <Link to={url} external>{row.targetSymbol}</Link>):
-         (<p> {row.targetSymbol} </p>)
+        return ensemblID !== "Symbol_Not_Found" ?
+          (<Link to={url} external>{row.targetSymbol}</Link>) :
+          (<p> {row.targetSymbol} </p>)
       },
       renderFilter: () => (
         <Autocomplete
@@ -304,22 +304,22 @@ class PMTLPage extends Component {
 
     return (
       <BasePageMTP title="PMTL">
-        <ScrollToTop/>
+        <ScrollToTop />
         <Typography variant="h4" component="h1" paragraph>
           US Food & Drug Administration Pediatric Molecular Target Lists (FDA
           PMTL)
         </Typography>
         <br />
         <Typography paragraph>
-        <Link to={FDA_PMTL_DocumentationUrl}> Version 1.1 </Link>
+          <Link to={FDA_PMTL_DocumentationUrl}> Version 1.1 </Link>
         </Typography>
         <hr />
         <br />
         <Typography paragraph>
-          Targets in the FDA's Pediatric Molecular Target Lists (PMTL) are important for studies 
-          of pediatric cancer and have special legal requirements associated with drug development. 
-          The table below is a computable interpretation of the target lists published by the FDA. 
-          See our  <Link to={FDA_PMTL_DocumentationUrl}> <b>FDA PMTL Documentation </b></Link> 
+          Targets in the FDA's Pediatric Molecular Target Lists (PMTL) are important for studies
+          of pediatric cancer and have special legal requirements associated with drug development.
+          The table below is a computable interpretation of the target lists published by the FDA.
+          See our  <Link to={FDA_PMTL_DocumentationUrl}> <b>FDA PMTL Documentation </b></Link>
           or the official <Link external to={FDA_Publication}><b>FDA publication{' '}</b> </Link>for details.
         </Typography>
         <Typography paragraph>

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -183,7 +183,7 @@ const downloadColumns = [
   { id: 'designation', label: 'designation' },
   { id: 'fdaClass', label: 'fdaClass' },
   { id: 'fdaTarget', label: 'fdaTarget' },
-  { id: 'mappingDescription', label: 'Mapping_Description' },
+  { id: 'mappingDescription', label: 'mappingDescription' },
 ];
 
 const getTargetSymbolOptions = rows => {

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -180,7 +180,7 @@ function getColumns(
 const downloadColumns = [
   { id: 'ensemblID', label: 'ensemblID' },
   { id: 'targetSymbol', label: 'targetSymbol' },
-  { id: 'designation', label: 'FDA_Designation' },
+  { id: 'designation', label: 'designation' },
   { id: 'fdaClass', label: 'FDA_Class' },
   { id: 'fdaTarget', label: 'FDA_Target' },
   { id: 'mappingDescription', label: 'Mapping_Description' },

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -179,7 +179,7 @@ function getColumns(
 
 const downloadColumns = [
   { id: 'ensemblID', label: 'ensemblID' },
-  { id: 'targetSymbol', label: 'Approved_Symbol' },
+  { id: 'targetSymbol', label: 'targetSymbol' },
   { id: 'designation', label: 'FDA_Designation' },
   { id: 'fdaClass', label: 'FDA_Class' },
   { id: 'fdaTarget', label: 'FDA_Target' },

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -181,7 +181,7 @@ const downloadColumns = [
   { id: 'ensemblID', label: 'ensemblID' },
   { id: 'targetSymbol', label: 'targetSymbol' },
   { id: 'designation', label: 'designation' },
-  { id: 'fdaClass', label: 'FDA_Class' },
+  { id: 'fdaClass', label: 'fdaClass' },
   { id: 'fdaTarget', label: 'FDA_Target' },
   { id: 'mappingDescription', label: 'Mapping_Description' },
 ];


### PR DESCRIPTION
In this PR:

- Under FDA PMTL Landing page, user can download the table records using JSON/CSV/TSV file format.
- Before the column name for JSON and CSV/TSV were different. With this PR, all downloaded column will follow the camelCase format.
- The following are the updated Column names:

    - ensemblID
    - targetSymbol
    - designation
    - fdaClass
    - fdaTarget
    - mappingDescription
