### PR TITLE
PPDC-539 (Add External link Icon | MVP)

### DIFF
--- a/src/components/ExternalLinkIcon.js
+++ b/src/components/ExternalLinkIcon.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core';
+import exLinkIcon from '../assets/about/About-ExternalLink.svg';
+
+const useStyles = makeStyles({
+  exLinkIcon: {
+    width: '20px',
+    margin: '0 0 0 2px',
+    verticalAlign: 'sub'
+  },
+});
+
+const ExternalLinkIcon = ({ className }) => {
+  const classes = useStyles();
+  return (
+    <img 
+      src={exLinkIcon} 
+      alt="outbounnd web site icon" 
+      className={className ? className : classes.exLinkIcon}
+    />
+  );
+};
+
+export default ExternalLinkIcon;

--- a/src/pages/AboutPage/AboutView.js
+++ b/src/pages/AboutPage/AboutView.js
@@ -20,8 +20,8 @@ import {
 import RelevantIcon from '../../components/RMTL/RelevantIcon';
 import NonRelevantIcon from '../../components/RMTL/NonRelevantIcon';
 import UnspecifiedIcon from '../../components/RMTL/UnspecifiedIcon';
-import externalIcon from '../../assets/about/About-ExternalLink.svg';
-import Infographic from '../../assets/about/Infographic.png'
+import ExternalLinkIcon from '../../components/ExternalLinkIcon';
+import Infographic from '../../assets/about/Infographic.png';
 import classNames from 'classnames';
 
 
@@ -63,11 +63,6 @@ const useStyles = makeStyles(theme => ({
   infographicContent: {
     flex: 1,
     paddingLeft: '20px'
-  },
-  externalIcon: {
-    width: '20px',
-    margin: '0 0 0 2px',
-    verticalAlign: 'sub'
   },
   log10: {
     verticalAlign: 'bottom'
@@ -212,8 +207,7 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE: 
           <Link to="https://www.fda.gov/about-fda/oncology-center-excellence/pediatric-oncology#target" external>{' '} 
-            FDA Pediatric Molecular Target List
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} /> {' '}
+            FDA Pediatric Molecular Target List<ExternalLinkIcon />{' '}
           </Link><br/> 
           Where this data is used in the MTP: 
           <Link to="/fda-pmtl">{' '} 
@@ -236,8 +230,7 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE: 
           <Link to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis" external>{' '} 
-            OpenPedCan (v10)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} /> {' '}
+            OpenPedCan (v10)<ExternalLinkIcon />{' '}
           </Link><br/> 
           Where this data is used in the MTP: OpenPedCan Somatic Alterations; OpenPedCan Gene Expression
         </p>
@@ -258,8 +251,7 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE: 
           <Link to="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000218.v23.p8" external>{' '} 
-            TARGET (v23)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} /> {' '}
+            TARGET (v23)<ExternalLinkIcon />{' '}
           </Link><br/> 
           Where this data is used in the MTP: OpenPedCan Somatic Alterations; OpenPedCan Gene Expression
         </p>
@@ -279,8 +271,7 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE: 
           <Link to="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001436.v1.p1" external>{' '} 
-            Kids First Neuroblastoma
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} /> {' '}
+            Kids First Neuroblastoma<ExternalLinkIcon />{' '}
           </Link><br/> 
           Where this data is used in the MTP: OpenPedCan Somatic Alterations; OpenPedCan Gene Expression
         </p>
@@ -293,31 +284,27 @@ const AboutView = ({ data }) => {
         <p>
           The Open Pediatric Brain Tumor Atlas (OpenPBTA) Project is an open science initiative led by 
           <Link to="https://www.alexslemonade.org/data-lab" external>{' '} 
-            Alex’s Lemonade Stand Foundation Childhood Cancer Data Lab 
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />{' '}
+            Alex’s Lemonade Stand Foundation Childhood Cancer Data Lab<ExternalLinkIcon />{' '}
           </Link>
           and the
           <Link to="https://d3b.center/" external>{' '} 
             Center for Data-Driven Discovery at the Children’s Hospital of Philadelphia 
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />{', '}
+            <ExternalLinkIcon />{', '}
           </Link> 
           which genomically characterized pediatric brain tumor data from the 
           <Link to="https://cbtn.org/" external>{' '} 
-            Children’s Brain Tumor Network (CBTN)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />{', '}
+            Children’s Brain Tumor Network (CBTN)<ExternalLinkIcon />{', '}
           </Link> 
           and the 
           <Link to="https://pnoc.us/" external>{' '} 
-            Pacific Pediatric Neuro-oncology Consortium (PNOC)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />{'. '}
+            Pacific Pediatric Neuro-oncology Consortium (PNOC)<ExternalLinkIcon />{'. '}
           </Link> 
           The Molecular Targets Platform includes OpenPBTA data from over 1,000 tumors spanning more than 30 histologies.
         </p>
         <p>
           SOURCE: 
           <Link to="https://alexslemonade.github.io/OpenPBTA-manuscript/" external>{' '} 
-            OpenPBTA for the CBTN (v21)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} /> {' '}
+            OpenPBTA for the CBTN (v21)<ExternalLinkIcon />{' '}
           </Link><br/> 
           Where this data is used in the MTP: OpenPedCan Somatic Alterations; OpenPedCan Gene Expression
         </p>
@@ -336,12 +323,10 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE: 
           <Link to="https://www.oncokb.org/news#07162021" external>{' '} 
-            OncoKB (v3.5)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            OncoKB (v3.5)<ExternalLinkIcon />
           </Link>{', '}
           <Link to="https://ascopubs.org/doi/full/10.1200/PO.17.00011" external>{' '} 
-            Chakravarty et al., JCO PO 2017
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            Chakravarty et al., JCO PO 2017<ExternalLinkIcon />
           </Link><br />
           Where this data is used in the MTP: OpenPedCan Somatic Alterations
         </p>
@@ -369,8 +354,7 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE: 
           <Link to="https://www.fda.gov/about-fda/oncology-center-excellence/pediatric-oncology#target" external>{' '} 
-            FDA Publications of Pediatric Molecular Target Lists
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            FDA Publications of Pediatric Molecular Target Lists<ExternalLinkIcon />
           </Link>
           
         </p>
@@ -400,8 +384,7 @@ const AboutView = ({ data }) => {
           SOURCE: 
           <Link to={"https://github.com/PediatricOpenTargets/OpenPedCan-analysis/blob/"+
                       "4fb04fe60754b90da3c241dbb8b727c3722487cc/doc/release-notes.md"} external>{' '} 
-            OpenPedCan (v10)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            OpenPedCan (v10)<ExternalLinkIcon />
           </Link>
           
         </p>
@@ -435,28 +418,22 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE: 
           <Link to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis" external> {' '}
-            OpenPedCan (v10)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            OpenPedCan (v10)<ExternalLinkIcon />
           </Link>{', '}
           <Link to="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000218.v23.p8" external>
-            TARGET (v23)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            TARGET (v23)<ExternalLinkIcon />
           </Link>{', '}
           <Link to="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001436.v1.p1" external> 
-            Kids First Neuroblastoma
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            Kids First Neuroblastoma<ExternalLinkIcon />
           </Link>{', '}
           <Link to="https://github.com/AlexsLemonade/OpenPBTA-analysis/" external>
-            OpenPBTA for CBTN and PNOC (v21) analysis
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            OpenPBTA for CBTN and PNOC (v21) analysis<ExternalLinkIcon />
           </Link>, and 
           <Link to="https://alexslemonade.github.io/OpenPBTA-manuscript/" external>{' '}
-            manuscript
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            manuscript<ExternalLinkIcon />
           </Link>{', '}
           <Link to="https://www.oncokb.org/news#07162021" external> 
-            OncoKB (v3.5)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            OncoKB (v3.5)<ExternalLinkIcon />
           </Link>
         </p>
       </div>
@@ -483,28 +460,22 @@ const AboutView = ({ data }) => {
         <p>
           SOURCE: 
           <Link to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis" external>{' '} 
-          OpenPedCan (v10)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            OpenPedCan (v10)<ExternalLinkIcon />
           </Link>, 
           <Link to="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000218.v23.p8" external>{' '} 
-          TARGET (v23)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            TARGET (v23)<ExternalLinkIcon />
           </Link>, 
           <Link to="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs001436.v1.p1" external>{' '} 
-          Kids First Neuroblastoma
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            Kids First Neuroblastoma<ExternalLinkIcon />
           </Link>,
           <Link to="https://github.com/AlexsLemonade/OpenPBTA-analysis/" external>{' '} 
-          OpenPBTA for CBTN and PNOC (v21) analysis
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            OpenPBTA for CBTN and PNOC (v21) analysis<ExternalLinkIcon />
           </Link>, and
           <Link to="https://alexslemonade.github.io/OpenPBTA-manuscript/" external>{' '} 
-          manuscript
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            manuscript<ExternalLinkIcon />
           </Link>,
           <Link to="https://www.oncokb.org/news#07162021" external>{' '} 
-            OncoKB (v3.5)
-            <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+            OncoKB (v3.5)<ExternalLinkIcon />
           </Link>
           
         </p>
@@ -539,7 +510,7 @@ const AboutView = ({ data }) => {
         <Typography paragraph>
           The Molecular Targets Platform is a National Cancer Institute (NCI) instance of the 
           <Link to="https://platform.opentargets.org/" external>{' '} 
-            Open Target Platform<img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} /> {' '}
+            Open Target Platform<ExternalLinkIcon />{' '}
           </Link>
           with a focus on pediatric cancer data. This tool allows users to browse and identify associations between molecular targets, diseases, and drugs. 
           The Molecular Targets Platform builds upon the data and functionality of the Open Targets Platform while also including: 
@@ -586,7 +557,7 @@ const AboutView = ({ data }) => {
         <Typography paragraph>
           The 
           <Link to="https://platform.opentargets.org/" external>{' '} 
-            Open Target Platform<img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} /> {' '}
+            Open Target Platform<ExternalLinkIcon />{' '}
           </Link>
           is the open-source infrastructure upon which the Molecular Targets Platform is built. 
 
@@ -616,11 +587,11 @@ const AboutView = ({ data }) => {
           This About page will document all of the new data and features present in the Molecular Targets Platform. 
           For detailed descriptions and tutorials of the built-in functions of the Open Targets Platform, please see their 
           <Link to="https://platform-docs.opentargets.org/" external>{' '} 
-            documentation<img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} /> {' '}
+            documentation<ExternalLinkIcon />{' '}
           </Link> 
           or their 
           <Link to="https://platform-docs.opentargets.org/citation" external>{' '} 
-             most recent publication.<img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} /> {' '}
+             most recent publication<ExternalLinkIcon />.
           </Link> 
         </Typography>
 
@@ -732,7 +703,7 @@ const AboutView = ({ data }) => {
                 <b>Version in use</b>: 21.06 (Released 2021-06-30) <br />
                 <b>Detailed Change Log</b>: 
                 <Link to="https://platform-docs.opentargets.org/change-log" external>{' '} 
-                  Open Target Platform <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+                  Open Target Platform<ExternalLinkIcon />
                 </Link>
               
               </div>
@@ -753,7 +724,7 @@ const AboutView = ({ data }) => {
                 <b>Version in use</b>: {version.frontend} <br />
                 <b>Detailed Change Log</b>: 
                 <Link to={version.frontendURL} external>{' '} 
-                  MTP Frontend Release <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+                  MTP Frontend Release<ExternalLinkIcon />
                 </Link>
               </div>
 
@@ -772,7 +743,7 @@ const AboutView = ({ data }) => {
                 <b>Version in use</b>: {version.backend} <br />
                 <b>Detailed Change Log</b>: 
                 <Link to={version.backendURL} external>{' '} 
-                  MTP Backend Release <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+                  MTP Backend Release<ExternalLinkIcon />
                 </Link>
               </div>
 
@@ -791,7 +762,7 @@ const AboutView = ({ data }) => {
                 <b>Version in use</b>: v10 (Released 2021-10-12) <br />
                 <b>Detailed Change Log</b>: 
                 <Link to="https://github.com/PediatricOpenTargets/OpenPedCan-analysis/blob/4fb04fe60754b90da3c241dbb8b727c3722487cc/doc/release-notes.md" external>{' '} 
-                  OpenPedCan Analysis Release <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+                  OpenPedCan Analysis Release<ExternalLinkIcon />
                 </Link>
               </div>
 
@@ -810,7 +781,7 @@ const AboutView = ({ data }) => {
                 <b>Version in use</b>: v3.5 (Released 2021-07-16) <br />
                 <b>Detailed Change Log</b>: 
                 <Link to="https://www.oncokb.org/news#07162021" external>{' '} 
-                  OncoKB Release <img src={externalIcon} alt="outbounnd web site icon" className={classes.externalIcon} />
+                  OncoKB Release<ExternalLinkIcon />
                 </Link>
               </div>
 

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -20,7 +20,7 @@ import {
   appDescription,
   appCanonicalUrl,
 } from '../../constants';
-import externalIcon from '../../assets/about/About-ExternalLink.svg';
+import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 
 
 const useStyles = makeStyles(theme => ({
@@ -40,9 +40,6 @@ const useStyles = makeStyles(theme => ({
   aboutBox:{
     margin: '70px 0',
   },
-  externalIcon: {
-    width: '15px',
-  }
 }));
 
 function pickTwo(arr) {
@@ -118,7 +115,8 @@ const HomePage = () => {
           <Typography paragraph align="center">
             The Molecular Targets Platform is an NCI-supported instance of the 
             <Link to={"https://platform.opentargets.org/"} external> Open Target Platform
-            <img src={externalIcon} alt="redirct to public open targets" className={classes.externalIcon} /></Link> with a focus on
+              <ExternalLinkIcon />
+            </Link> with a focus on
              preclinical pediatric oncology data. It is a tool that supports the identification and 
              prioritization of molecular targets expressed in childhood cancers. 
           </Typography>

--- a/src/pages/PMTLDocPage/index.js
+++ b/src/pages/PMTLDocPage/index.js
@@ -3,6 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Grid, Typography, Avatar, Paper } from '@material-ui/core';
 import BasePageMTP from '../../components/BasePageMTP';
 import Link from '../../components/Link'
+import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
@@ -194,9 +195,11 @@ function PMTLDocPage() {
                   The targets in these lists have <b> special legal requirements</b> associated with drug development.
             </Typography>
             <Typography paragraph>
-              While the  <Link to={fDPublicationLink} external>
-                <b>FDA publications </b>
-              </Link>
+              While the{' '}  
+              <Link to={fDPublicationLink} external>
+                <b>FDA publications</b>
+                <ExternalLinkIcon />
+              </Link>{' '}
               remain the authoritative source for these targets, a computable interpretation of the lists is integrated into the Molecular Targets Platform.
             </Typography>
             <Typography paragraph>

--- a/src/pages/PMTLDocPage/index.js
+++ b/src/pages/PMTLDocPage/index.js
@@ -292,6 +292,7 @@ function PMTLDocPage() {
               resolution by a unique (
               <Link to={ensemblStableIDLink} external>
                 <b>Ensembl stable ID</b>
+                <ExternalLinkIcon />
               </Link>
               ), and then mapped to other information (e.g. gene name and
               symbol). As published, the FDA PMTL does not use

--- a/src/pages/PMTLDocPage/index.js
+++ b/src/pages/PMTLDocPage/index.js
@@ -329,6 +329,7 @@ function PMTLDocPage() {
               3. Using Human Genome Organization Gene Nomenclature Committee (
               <Link to={hugoHgncLink} external>
                 HUGO HGNC
+                <ExternalLinkIcon />
               </Link>
               ) resources, manually standardized the names and symbols of all
               targets, which enabled mapping each target to Ensembl gene IDs.

--- a/src/pages/PMTLDocPage/index.js
+++ b/src/pages/PMTLDocPage/index.js
@@ -4,6 +4,8 @@ import { Grid, Typography, Avatar, Paper } from '@material-ui/core';
 import BasePageMTP from '../../components/BasePageMTP';
 import Link from '../../components/Link'
 import ExternalLinkIcon from '../../components/ExternalLinkIcon';
+import ScrollToTop from '../../components/ScrollToTop';
+
 const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
@@ -178,6 +180,7 @@ function PMTLDocPage() {
 
   return (
     <BasePageMTP title="PMTL Document">
+      <ScrollToTop />
       <div className={classes.root}>
         <Grid container spacing={3}>
           <Grid item xs={12}>

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
-import { Paper, Box, Typography, TextField } from '@material-ui/core';
+import { Paper, Box, Typography, TextField, Link as Lk } from '@material-ui/core';
 import { Autocomplete } from '@material-ui/lab';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import crossfilter from 'crossfilter2';
 import _ from 'lodash';
 
@@ -12,11 +14,8 @@ import RelevantIcon from '../../components/RMTL/RelevantIcon';
 import NonRelevantIcon from '../../components/RMTL/NonRelevantIcon';
 import UnspecifiedIcon from '../../components/RMTL/UnspecifiedIcon';
 import ScrollToTop from '../../components/ScrollToTop';
-import PMTLData from './PMTL.json';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
-import { Link as Lk } from '@material-ui/core';
 import ExternalLinkIcon from '../../components/ExternalLinkIcon';
+import PMTLData from './PMTL.json';
 
 function getRows(downloadData) {
   const rows = [];
@@ -346,8 +345,7 @@ class PMTLPage extends Component {
                   href="/fda-pmtl-docs#colums-description"
                   title="FDA PMTL Columns Description"
                 >
-                  <FontAwesomeIcon icon={faInfoCircle} size="md" /> Columns
-                  Description
+                  <FontAwesomeIcon icon={faInfoCircle} size="md" /> Columns Description
                 </Lk>
                 <DataDownloader
                   tableHeaders={downloadColumns}

--- a/src/pages/PMTLPage/PMTLPage.js
+++ b/src/pages/PMTLPage/PMTLPage.js
@@ -16,6 +16,7 @@ import PMTLData from './PMTL.json';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { Link as Lk } from '@material-ui/core';
+import ExternalLinkIcon from '../../components/ExternalLinkIcon';
 
 function getRows(downloadData) {
   const rows = [];
@@ -320,7 +321,12 @@ class PMTLPage extends Component {
           of pediatric cancer and have special legal requirements associated with drug development.
           The table below is a computable interpretation of the target lists published by the FDA.
           See our  <Link to={FDA_PMTL_DocumentationUrl}> <b>FDA PMTL Documentation </b></Link>
-          or the official <Link external to={FDA_Publication}><b>FDA publication{' '}</b> </Link>for details.
+          or the official{' '}
+          <Link external to={FDA_Publication}>
+            <b>FDA publication</b>
+            <ExternalLinkIcon />
+          </Link>{' '}
+          for details.
         </Typography>
         <Typography paragraph>
           Each target in the list is designated as either a <RelevantIcon />{' '}


### PR DESCRIPTION
In this PR:
- Reusable ExternalLinkIcon component is created
- External link Icon has been added for all external link under FDA PMTL Landing and Documentation Page.
- Update Home and About Page to use ExternalLinkIcon component
- Add scroll to Top functionality and refactor codes

Related Ticket: PPDC-539